### PR TITLE
Revamped Structure loading API

### DIFF
--- a/battlecode-engine/src/controller.rs
+++ b/battlecode-engine/src/controller.rs
@@ -649,6 +649,67 @@ impl GameController {
     }
 
     // ************************************************************************
+    // ************************* STRUCTURE METHODS ****************************
+    // ************************************************************************
+
+    /// Whether the robot can be loaded into the given structure's garrison. The robot
+    /// must be ready to move and must be adjacent to the structure. The structure
+    /// and the robot must be on the same team, and the structure must have space.
+    ///
+    /// * GameError::NoSuchUnit - a unit does not exist.
+    /// * GameError::TeamNotAllowed - either unit is not on the current player's team.
+    /// * GameError::InappropriateUnitType - the robot or structure are the wrong type.
+    pub fn can_load(&self, structure_id: UnitID, robot_id: UnitID)
+                        -> Result<bool, Error> {
+        Ok(self.world.can_load(structure_id, robot_id)?)
+    }
+
+    /// Loads the robot into the garrison of the structure.
+    ///
+    /// * GameError::NoSuchUnit - a unit does not exist.
+    /// * GameError::TeamNotAllowed - either unit is not on the current player's team.
+    /// * GameError::InappropriateUnitType - the robot or structure are the wrong type.
+    /// * GameError::InvalidAction - the robot cannot be loaded inside the structure.
+    pub fn load(&mut self, structure_id: UnitID, robot_id: UnitID)
+                    -> Result<(), Error> {
+        let delta = Delta::Load { structure_id, robot_id };
+        if self.config.generate_turn_messages {
+            self.turn.changes.push(delta.clone());
+        }
+        Ok(self.world.apply(&delta)?)
+    }
+
+    /// Tests whether the given structure is able to unload a unit in the
+    /// given direction. There must be space in that direction, and the unit
+    /// must be ready to move.
+    ///
+    /// * GameError::NoSuchUnit - the unit does not exist (inside the vision range).
+    /// * GameError::TeamNotAllowed - the unit is not on the current player's team.
+    /// * GameError::InappropriateUnitType - the unit is not a structure.
+    /// * GameError::InvalidLocation - the location is off the map.
+    pub fn can_unload(&self, structure_id: UnitID, direction: Direction)
+                                 -> Result<bool, Error> {
+        Ok(self.world.can_unload(structure_id, direction)?)
+    }
+
+    /// Unloads a robot from the garrison of the specified structure into an 
+    /// adjacent space. Robots are unloaded in the order they were loaded.
+    ///
+    /// * GameError::NoSuchUnit - the unit does not exist (inside the vision range).
+    /// * GameError::TeamNotAllowed - the unit is not on the current player's team.
+    /// * GameError::InappropriateUnitType - the unit is not a structure.
+    /// * GameError::InvalidLocation - the location is off the map.
+    /// * GameError::InvalidAction - the rocket cannot degarrison a unit.
+    pub fn unload(&mut self, structure_id: UnitID, direction: Direction)
+                      -> Result<(), Error> {
+        let delta = Delta::Unload { structure_id, direction };
+        if self.config.generate_turn_messages {
+            self.turn.changes.push(delta.clone());
+        }
+        Ok(self.world.apply(&delta)?)
+    }
+
+    // ************************************************************************
     // ************************** FACTORY METHODS *****************************
     // ************************************************************************
 
@@ -665,31 +726,6 @@ impl GameController {
         unimplemented!();
     }
 
-    /// Tests whether the factory is able to degarrison a unit in the given
-    /// direction. There must be space in that direction.
-    ///
-    /// * GameError::NoSuchUnit - the unit does not exist (inside the vision range).
-    /// * GameError::TeamNotAllowed - the unit is not on the current player's team.
-    /// * GameError::InappropriateUnitType - the unit is not a factory.
-    /// * GameError::InvalidLocation - the location is off the map.
-    pub fn can_degarrison_factory(&self, _factory_id: UnitID,
-                                  _direction: Direction) -> Result<bool, Error> {
-        unimplemented!();
-    }
-
-    /// Degarrisons a robot from the garrison of the specified factory. Robots
-    /// are degarrisoned in the order they garrisoned.
-    ///
-    /// * GameError::NoSuchUnit - the unit does not exist (inside the vision range).
-    /// * GameError::TeamNotAllowed - the unit is not on the current player's team.
-    /// * GameError::InappropriateUnitType - the unit is not a factory.
-    /// * GameError::InvalidLocation - the location is off the map.
-    /// * GameError::InvalidAction - the factory cannot degarrison a unit.
-    pub fn degarrison_factory(&mut self, _factory_id: UnitID,
-                              _direction: Direction) -> Result<(), Error> {
-        unimplemented!();
-    }
-
     /// Process the end of the turn for factories. If a factory added a unit
     /// to its garrison, also mark that unit down in the game world.
     fn _process_factory(&self) {
@@ -700,83 +736,6 @@ impl GameController {
     // ************************************************************************
     // *************************** ROCKET METHODS *****************************
     // ************************************************************************
-
-    /*
-    /// Whether the robot can garrison inside the rocket. The robot must be
-    /// ready to move and adjacent to the rocket. The rocket must be on the
-    /// same team and have enough space.
-    ///
-    /// * GameError::NoSuchUnit - a unit does not exist.
-    /// * GameError::TeamNotAllowed - the rocket is not on the current player's team.
-    /// * GameError::InappropriateUnitType - the robot or rocket are the wrong type.
-    pub fn can_garrison_rocket(&self, rocket_id: UnitID, robot_id: UnitID)
-                        -> Result<bool, Error> {
-        let robot = self.get_unit(robot_id)?;
-        let rocket = self.get_unit(rocket_id)?;
-        rocket.can_garrison(robot)
-    }
-
-    /// Moves the robot into the garrison of the rocket.
-    ///
-    /// * GameError::NoSuchUnit - a unit does not exist.
-    /// * GameError::TeamNotAllowed - the robot or rocket is not on the current player's team.
-    /// * GameError::InappropriateUnitType - the robot or rocket are the wrong type.
-    /// * GameError::InvalidAction - the robot cannot garrison inside the rocket.
-    pub fn garrison_rocket(&mut self, rocket_id: UnitID, robot_id: UnitID)
-                    -> Result<(), Error> {
-        if self.can_garrison_rocket(rocket_id, robot_id)? {
-            self.get_unit_mut(rocket_id)?.garrison(robot_id)?;
-            self.remove_unit(robot_id)?;
-            self.get_unit_mut(robot_id)?.move_to(None)?;
-            Ok(())
-        } else {
-            Err(GameError::InvalidAction)?
-        }
-    }
-
-    /// Tests whether the given rocket is able to degarrison a unit in the
-    /// given direction. There must be space in that direction, and the unit
-    /// must be ready to move.
-    ///
-    /// * GameError::NoSuchUnit - the unit does not exist (inside the vision range).
-    /// * GameError::TeamNotAllowed - the unit is not on the current player's team.
-    /// * GameError::InappropriateUnitType - the unit is not a rocket.
-    /// * GameError::InvalidLocation - the location is off the map.
-    pub fn can_degarrison_rocket(&self, rocket_id: UnitID, direction: Direction)
-                                 -> Result<bool, Error> {
-        let rocket = self.get_unit(rocket_id)?;
-        if rocket.can_degarrison_unit()? {
-            let robot = self.get_unit(rocket.garrisoned_units()?[0])?;
-            let loc = rocket.location().unwrap().add(direction);
-            Ok(self.is_occupiable(loc)? && robot.is_move_ready()?)
-        } else {
-            Ok(false)
-        }
-    }
-
-    /// Degarrisons a robot from the garrison of the specified rocket. Robots
-    /// are degarrisoned in the order they garrisoned.
-    ///
-    /// * GameError::NoSuchUnit - the unit does not exist (inside the vision range).
-    /// * GameError::TeamNotAllowed - the unit is not on the current player's team.
-    /// * GameError::InappropriateUnitType - the unit is not a rocket.
-    /// * GameError::InvalidLocation - the location is off the map.
-    /// * GameError::InvalidAction - the rocket cannot degarrison a unit.
-    pub fn degarrison_rocket(&mut self, rocket_id: UnitID, direction: Direction)
-                      -> Result<(), Error> {
-        if self.can_degarrison_rocket(rocket_id, direction)? {
-            let (robot_id, rocket_loc) = {
-                let rocket = self.get_unit_mut(rocket_id)?;
-                (rocket.degarrison_unit()?, rocket.location().unwrap())
-            };
-            let robot_loc = rocket_loc.add(direction);
-            self.get_unit_mut(robot_id)?.move_to(Some(robot_loc))?;
-            self.place_unit(robot_id)
-        } else {
-            Err(GameError::InvalidAction)?
-        }
-    }
-    */
 
     /// Whether the rocket can launch into space. The rocket can launch if the
     /// it has never been used before.

--- a/battlecode-engine/src/schema.rs
+++ b/battlecode-engine/src/schema.rs
@@ -20,12 +20,8 @@ pub enum Delta {
     Blink { mage_id: UnitID, location: MapLocation },
     /// Commands the given worker to build a blueprint.
     Build { worker_id: UnitID, blueprint_id: UnitID },
-    /// Commands the given structure to degarrison a unit in the given direction.
-    Degarrison { structure_id: UnitID, direction: Direction },
     /// Commands the given unit to disintegrate.
     Disintegrate { unit_id: UnitID },
-    /// Commands the given structure to pull the specified robot into its garrison.
-    Garrison { structure_id: UnitID, robot_id: UnitID },
     /// Commands the given worker to mine karbonite from an adjacent square.
     Harvest { worker_id: UnitID, direction: Direction },
     /// Commands the given healer to heal the given robot.
@@ -34,6 +30,8 @@ pub enum Delta {
     Javelin { knight_id: UnitID, target_unit_id: UnitID },
     /// Commands the given rocket to launch, ultimately landing in the specified location.
     LaunchRocket { rocket_id: UnitID, location: MapLocation },
+    /// Commands the given structure to load the specified robot into its garrison.
+    Load { structure_id: UnitID, robot_id: UnitID },
     /// Commands the given robot to move in the given direction.
     Move { robot_id: UnitID, direction: Direction },
     /// Commands the given healer to overcharge the specified robot.
@@ -48,6 +46,8 @@ pub enum Delta {
     Replicate { worker_id: UnitID, direction: Direction },
     /// Resets the current research queue, for the specified team.
     ResetResearchQueue { team: Team },
+    /// Commands the given structure to unload a unit in the given direction.
+    Unload { structure_id: UnitID, direction: Direction },
     /// Nothing happens.
     Nothing,
 }

--- a/battlecode-engine/src/unit.rs
+++ b/battlecode-engine/src/unit.rs
@@ -178,6 +178,8 @@ pub struct Unit {
 
     // Factories and rockets.
     is_built: bool,
+    max_capacity: usize,
+    garrison: Vec<UnitID>,
 
     // Worker special ability.
     build_health: u32,
@@ -203,9 +205,7 @@ pub struct Unit {
 
     // Rocket special ability.
     is_used: bool,
-    max_capacity: usize,
     travel_time_multiplier: Percent,
-    garrisoned_units: Vec<UnitID>,
 }
 
 impl Default for Unit {
@@ -233,6 +233,8 @@ impl Default for Unit {
             ability_range: 0,
 
             is_built: false,
+            max_capacity: 8,
+            garrison: vec![],
             build_health: 5,
             harvest_amount: 3,
             has_harvested: false,
@@ -244,9 +246,7 @@ impl Default for Unit {
             self_heal_amount: 1,
             production_queue: vec![],
             is_used: false,
-            max_capacity: 8,
             travel_time_multiplier: 100,
-            garrisoned_units: vec![],
         }
     }
 }
@@ -311,6 +311,15 @@ impl Unit {
             Ranger => Ok(()),
             Mage   => Ok(()),
             Healer => Ok(()),
+            _ => Err(GameError::InappropriateUnitType)?,
+        }
+    }
+
+    /// Ok if the unit is a structure. Errors otherwise.
+    fn ok_if_structure(&self) -> Result<(), Error> {
+        match self.unit_type {
+            Rocket  => Ok(()),
+            Factory => Ok(()),
             _ => Err(GameError::InappropriateUnitType)?,
         }
     }
@@ -514,6 +523,72 @@ impl Unit {
     // ************************************************************************
 
     // ************************************************************************
+    // ************************* STRUCTURE METHODS ****************************
+    // ************************************************************************
+
+    /// The max capacity of a structure.
+    ///
+    /// Errors if the unit is not a structure.
+    pub fn max_capacity(&self) -> Result<usize, Error> {
+        self.ok_if_structure()?;
+        Ok(self.max_capacity)
+    }
+
+    /// Returns the units in the structure's garrison.
+    ///
+    /// Errors if the unit is not a structure.
+    pub fn garrison(&self) -> Result<Vec<UnitID>, Error> {
+        self.ok_if_structure()?;
+        Ok(self.garrison.clone())
+    }
+
+    /// Whether the structure can load a unit. The unit must be ready to move
+    /// and adjacent to the structure. The structure must have enough space.
+    ///
+    /// Errors if this unit is not a structure.
+    pub fn can_load(&self, robot: &Unit) -> Result<bool, Error> {
+        Ok(robot.is_move_ready()?
+            && self.garrison()?.len() < self.max_capacity()?
+            && self.team == robot.team
+            && self.is_adjacent_to(robot.location()))
+    }
+
+    /// Updates the structure as if it has loaded a unit inside its garrison.
+    /// Adds the unit ID to the garrison.
+    ///
+    /// Errors if this unit is not a structure, or it cannot load.
+    pub fn load(&mut self, id: UnitID) -> Result<(), Error> {
+        if self.garrison()?.len() < self.max_capacity()? {
+            self.ok_if_structure()?;
+            self.garrison.push(id);
+            Ok(())
+        } else {
+            Err(GameError::InvalidAction)?
+        }
+    }
+
+    /// Whether the structure can unload a unit. The structure must be on a
+    /// planet and it must have at least one unit to unload. Does not check
+    /// whether the unit is ready to move.
+    ///
+    /// Errors if the unit is not a structure.
+    pub fn can_unload_unit(&self) -> Result<bool, Error> {
+        Ok(self.location().is_some() && self.garrison()?.len() > 0)
+    }
+
+    /// Updates the structure as if it has unloaded a single unit from the
+    /// structure, returning the unit ID.
+    ///
+    /// Errors if the unit is not a structure, or it cannot unload.
+    pub fn unload_unit(&mut self) -> Result<UnitID, Error> {
+        if self.can_unload_unit()? {
+            Ok(self.garrison.remove(0))
+        } else {
+            Err(GameError::InvalidAction)?
+        }
+    }
+
+    // ************************************************************************
     // ************************** FACTORY METHODS *****************************
     // ************************************************************************
 
@@ -521,53 +596,12 @@ impl Unit {
     // *************************** ROCKET METHODS *****************************
     // ************************************************************************
 
-    /// The max capacity of a rocket.
-    ///
-    /// Errors if the unit is not a rocket.
-    pub fn max_capacity(&self) -> Result<usize, Error> {
-        self.ok_if_unit_type(Rocket)?;
-        Ok(self.max_capacity)
-    }
-
     /// Whether the rocket has already been used.
     ///
     /// Errors if the unit is not a rocket.
     pub fn is_rocket_used(&self) -> Result<bool, Error> {
         self.ok_if_unit_type(Rocket)?;
         Ok(self.is_used)
-    }
-
-    /// Returns the garrisoned units in a rocket.
-    ///
-    /// Errors if the unit is not a rocket.
-    pub fn garrisoned_units(&self) -> Result<Vec<UnitID>, Error> {
-        self.ok_if_unit_type(Rocket)?;
-        Ok(self.garrisoned_units.clone())
-    }
-
-    /// Whether the rocket can garrison a unit. The unit must be ready to move
-    /// and adjacent to the rocket. The rocket must have enough space.
-    ///
-    /// Errors if the unit is not a rocket.
-    pub fn can_garrison(&self, robot: &Unit) -> Result<bool, Error> {
-        Ok(robot.is_move_ready()?
-            && self.garrisoned_units()?.len() < self.max_capacity()?
-            && self.team == robot.team
-            && self.is_adjacent_to(robot.location()))
-    }
-
-    /// Updates the rocket as if it has garrisoned a unit inside the rocket.
-    /// Adds the unit ID to the garrison.
-    ///
-    /// Errors if the unit is not a rocket, or it cannot garrison.
-    pub fn garrison(&mut self, id: UnitID) -> Result<(), Error> {
-        if self.garrisoned_units()?.len() < self.max_capacity()? {
-            self.ok_if_unit_type(Rocket)?;
-            self.garrisoned_units.push(id);
-            Ok(())
-        } else {
-            Err(GameError::InvalidAction)?
-        }
     }
 
     /// Whether the rocket can launch. It must not be used and it must
@@ -600,27 +634,6 @@ impl Unit {
             self.ok_if_unit_type(Rocket)?;
             self.location = Some(location);
             Ok(())
-        } else {
-            Err(GameError::InvalidAction)?
-        }
-    }
-
-    /// Whether the rocket can degarrison a unit. The rocket must be on a
-    /// planet and it must have at least one unit to degarrison. Does not check
-    /// whether the unit is ready to move.
-    ///
-    /// Errors if the unit is not a rocket.
-    pub fn can_degarrison_unit(&self) -> Result<bool, Error> {
-        Ok(self.location().is_some() && self.garrisoned_units()?.len() > 0)
-    }
-
-    /// Updates the rocket as if it has degarrisoned a single unit from the
-    /// rocket, returning the unit ID.
-    ///
-    /// Errors if the unit is not a rocket, or it cannot degarrison.
-    pub fn degarrison_unit(&mut self) -> Result<UnitID, Error> {
-        if self.can_degarrison_unit()? {
-            Ok(self.garrisoned_units.remove(0))
         } else {
             Err(GameError::InvalidAction)?
         }
@@ -788,30 +801,30 @@ mod tests {
         // Rocket accessor methods should fail on a robot.
         assert!(robot.max_capacity().is_err());
         assert!(robot.is_rocket_used().is_err());
-        assert!(robot.garrisoned_units().is_err());
-        assert!(robot.garrison(0).is_err());
+        assert!(robot.garrison().is_err());
+        assert!(robot.load(0).is_err());
         assert!(robot.can_launch_rocket().is_err());
         assert!(robot.launch_rocket().is_err());
         assert!(robot.land_rocket(loc).is_err());
-        assert!(robot.can_degarrison_unit().is_err());
-        assert!(robot.degarrison_unit().is_err());
+        assert!(robot.can_unload_unit().is_err());
+        assert!(robot.unload_unit().is_err());
 
         // Check accessor methods on the rocket.
         assert!(rocket.max_capacity().unwrap() > 0);
         assert!(!rocket.is_rocket_used().unwrap());
-        assert_eq!(rocket.garrisoned_units().unwrap().len(), 0);
-        assert!(rocket.can_garrison(&robot).unwrap());
-        assert!(!rocket.can_degarrison_unit().unwrap());
+        assert_eq!(rocket.garrison().unwrap().len(), 0);
+        assert!(rocket.can_load(&robot).unwrap());
+        assert!(!rocket.can_unload_unit().unwrap());
         assert!(rocket.can_launch_rocket().unwrap());
 
         // The rocket cannot land.
         assert!(rocket.land_rocket(mars_loc).is_err());
 
-        // Garrison a unit and launch into space.
-        assert!(rocket.garrison(robot.id()).is_ok());
+        // Load a unit and launch into space.
+        assert!(rocket.load(robot.id()).is_ok());
         robot.move_to(None).unwrap();
-        assert_eq!(rocket.garrisoned_units().unwrap(), vec![robot.id()]);
-        assert!(rocket.can_degarrison_unit().unwrap());
+        assert_eq!(rocket.garrison().unwrap(), vec![robot.id()]);
+        assert!(rocket.can_unload_unit().unwrap());
         assert_eq!(rocket.launch_rocket().unwrap(), ());
         assert_eq!(rocket.location(), None);
         assert!(rocket.is_rocket_used().unwrap());
@@ -822,19 +835,19 @@ mod tests {
         assert_eq!(rocket.land_rocket(mars_loc).unwrap(), ());
         assert_eq!(rocket.location(), Some(mars_loc));
 
-        // Degarrison the unit.
-        assert!(rocket.can_degarrison_unit().unwrap());
-        assert_eq!(rocket.degarrison_unit().unwrap(), robot.id());
-        assert!(!rocket.can_degarrison_unit().unwrap());
+        // Unload the unit.
+        assert!(rocket.can_unload_unit().unwrap());
+        assert_eq!(rocket.unload_unit().unwrap(), robot.id());
+        assert!(!rocket.can_unload_unit().unwrap());
 
-        // Garrison too many units
+        // Load too many units
         let robot = Unit::new(0, Team::Red, Mage, 0, adjacent_mars_loc).unwrap();
         for i in 0..rocket.max_capacity().unwrap() {
-            assert!(rocket.can_garrison(&robot).unwrap(), "failed to garrison unit {}", i);
-            assert!(rocket.garrison(0).is_ok());
+            assert!(rocket.can_load(&robot).unwrap(), "failed to load unit {}", i);
+            assert!(rocket.load(0).is_ok());
         }
-        assert!(!rocket.can_garrison(&robot).unwrap());
-        assert!(rocket.garrison(0).is_err());
+        assert!(!rocket.can_load(&robot).unwrap());
+        assert!(rocket.load(0).is_err());
     }
 
     #[test]


### PR DESCRIPTION
Garrison was a clunky verb. This PR changes that to "load"/"unload", and also lets rockets and factories use the same methods for manipulating their garrisons.