### PR TITLE
Don't add movement heat when unloading

### DIFF
--- a/battlecode-engine/src/unit.rs
+++ b/battlecode-engine/src/unit.rs
@@ -501,6 +501,12 @@ impl Unit {
         self.location = OnMap(location);
     }
 
+    /// Updates the unit's location as it if has moved, but without increasing
+    /// the movement heat.
+    pub(crate) fn move_to_noheat(&mut self, location: MapLocation) {
+        self.location = OnMap(location);
+    }
+
     /// Ok if the robot can attack the target location. Overloaded for the
     /// healer's heal.
     ///


### PR DESCRIPTION
Spec says: "Loading is treated like a robot’s standard move action, though unloading has no effect or dependency on the movement heat." Changing the spec would also be possible, of course.