### PR TITLE
Make build slightly more stable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,9 +18,9 @@ release: battlecode
 	@$(MAKE) copy
 
 copy:
-	cp -R bindings/python/battlecode battlecode/python/battlecode
-	cp -R bindings/java/src/bc battlecode/java/bc
-	cp -R bindings/c/include battlecode/c/include
+	cp -R bindings/python/battlecode battlecode/python/
+	cp -R bindings/java/src/bc battlecode/java/
+	cp -R bindings/c/include battlecode/c/
 
 copy-linux:
 	mkdir -p docker-artifacts
@@ -37,7 +37,7 @@ copy-win32:
 battlecode:
 	rm -rf battlecode
 	mkdir -p battlecode/python/
-	mkdir -p battlecode/c/lib
+	mkdir -p battlecode/c/lib/
 	mkdir -p battlecode/java/
 
 test:

--- a/bindings/python/bc_build.py
+++ b/bindings/python/bc_build.py
@@ -50,7 +50,8 @@ ffibuilder.set_source(
     contents,
     library_dirs=library_dirs,
     libraries=libraries,
-    extra_link_args=extra_link_args
+    extra_link_args=extra_link_args,
+    depends=extra_link_args
 )
 
 if __name__ == '__main__':


### PR DESCRIPTION
A lone `make copy` silently fails without this change (it copies the directory into the existing one), and so does `make`/`make release` inside `bindings/python/` (it doesn't do anything, because it doesn't understand that the updated `.a` file is relevant).