### PR TITLE
Fix Java OOMs

### DIFF
--- a/bindings/frankenswig/function.py
+++ b/bindings/frankenswig/function.py
@@ -81,7 +81,7 @@ class Method(Function):
 
     def to_swig(self):
         result = s(f'''\
-            %newobject {self.name};
+            %newobject {self.method_name};
             {self.type.to_swig()} {self.method_name}({', '.join(a.to_swig() for a in self.args[1:])});
         ''')
         return result


### PR DESCRIPTION
Turns out Java was leaking every single object returned from the API.

`examplefuncsplayer-java` works with this change; however, I haven't tested any more complicated bot, nor checked whether other places are similarly broken.