### PR TITLE
Fix snipe

### DIFF
--- a/battlecode-engine/src/world.rs
+++ b/battlecode-engine/src/world.rs
@@ -1562,24 +1562,25 @@ impl GameWorld {
         Ok(())
     }
 
-    fn process_rangers(&mut self, planet: Planet) {
-        let mut rangers: Vec<UnitID> = vec![];
-        for unit in self.get_planet(planet).units.values() {
-            if unit.unit_type() == UnitType::Ranger {
-                rangers.push(unit.id());
+    fn process_rangers(&mut self) {
+        let team = self.team();
+        let mut targets: Vec<(MapLocation, i32, UnitID)> = vec![];
+
+        for unit in self.my_planet_mut().units.values_mut() {
+            if unit.team() == team && unit.unit_type() == UnitType::Ranger {
+                let target = unit.process_snipe();
+                if let Some(target) = target {
+                    targets.push((target, unit.damage().unwrap(), unit.id()));
+                }
             }
         }
 
-        for id in rangers {
-            let target_location = self.get_planet_mut(planet).units.get_mut(&id).unwrap().process_snipe();
-            if target_location.is_some() {
-                let damage = self.get_planet(planet).units.get(&id).unwrap().damage().unwrap();
-                self.damage_location(target_location.unwrap(), damage);
-                self.viewer_changes.push(ViewerDelta::RangerSnipe { 
-                    ranger_id: id, 
-                    target_location: target_location.unwrap(), 
-                });
-            }
+        for (target, damage, id) in targets {
+            self.damage_location(target, damage);
+            self.viewer_changes.push(ViewerDelta::RangerSnipe {
+                ranger_id: id,
+                target_location: target
+            });
         }
     }
 
@@ -2076,6 +2077,9 @@ impl GameWorld {
             self.process_rockets(team);
         }
 
+        // Process ranger snipes.
+        self.process_rangers();
+
         let player = self.player_to_move;
         let world = self.filter(player);
         let mut stm = StartTurnMessage {
@@ -2166,10 +2170,6 @@ impl GameWorld {
         // Passive karbonite production.
         self.process_karbonite(Team::Red);
         self.process_karbonite(Team::Blue);
-
-        // Process ranger snipes.
-        self.process_rangers(Planet::Earth);
-        self.process_rangers(Planet::Mars);
 
         // Add produced factory robots to the garrison.
         self.process_factories();
@@ -2756,8 +2756,8 @@ mod tests {
 
         // Enough rounds pass where Ranger's snipe is processed
         let rounds = 200;
-        for _ in 0..rounds {
-            world.end_round();
+        for _ in 0..4*rounds {
+            world.end_turn();
         }
         
         // Robot at sniped location should take damage


### PR DESCRIPTION
Fixes #117. Snipes are now processed in the beginning of each turn instead of at the end of each round, which in addition to fixing the problem also makes it more fair: previously, red only had 4 turns to escape blue's snipe, while blue had 5.

Also, it fixes a crash in the case where two snipers would kill each other with snipe during the same round -- one would destroy the other, then the unwrap of the other unit would fail. (The viewer could potentially have a similar bug, I don't know. At least pushing a possibly invalidated unit id with `self.viewer_changes.push(ViewerDelta::RangerSnipe { ranger_id: id, ... })` does feel risky, but maybe the viewers handle it.)