### PR TITLE
Add 'team' field to ResearchComplete events

### DIFF
--- a/battlecode-engine/src/schema.rs
+++ b/battlecode-engine/src/schema.rs
@@ -124,7 +124,7 @@ pub enum ViewerDelta {
     KarboniteChanged { location: MapLocation, new_amount: u32 },
     ProductionDone { factory_id: UnitID, unit_type: UnitType },
     RangerSnipe { ranger_id: UnitID, target_location: MapLocation },
-    ResearchComplete { branch: UnitType },
+    ResearchComplete { branch: UnitType, team: Team },
     RocketLanding { rocket_id: UnitID, location: MapLocation },
 }
 

--- a/battlecode-engine/src/world.rs
+++ b/battlecode-engine/src/world.rs
@@ -1192,7 +1192,7 @@ impl GameWorld {
                     unit.research().expect("research level is valid");
                 }
             }
-            self.viewer_changes.push(ViewerDelta::ResearchComplete { branch });
+            self.viewer_changes.push(ViewerDelta::ResearchComplete { branch, team });
         }
     }
 


### PR DESCRIPTION
Right now it's impossible to tell who did what research, which is quite silly.