### PR TITLE
Fix overcharge

### DIFF
--- a/battlecode-engine/src/unit.rs
+++ b/battlecode-engine/src/unit.rs
@@ -886,10 +886,8 @@ impl Unit {
     /// a robot and not a healer.
     ///
     /// * InappropriateUnitType - the unit is not a robot or is a healer.
-    /// * ResearchNotUnlocked - the unit's ability is not unlocked.
     pub(crate) fn ok_if_can_be_overcharged(& self) -> Result<(), Error> {
         self.ok_if_robot()?;
-        self.ok_if_ability_unlocked()?;
         if self.ok_if_unit_type(Healer).is_ok() {
             Err(GameError::InappropriateUnitType)?
         }

--- a/battlecode-engine/src/world.rs
+++ b/battlecode-engine/src/world.rs
@@ -3492,8 +3492,8 @@ mod tests {
         let mars_enemy = world.create_unit(Team::Blue, mars_loc.add(Direction::East), UnitType::Healer).unwrap();
 
         // go to red mars turn
-        world.end_turn();
-        world.end_turn();
+        world.end_turn(FILLER_TIME);
+        world.end_turn(FILLER_TIME);
 
         // sense that unit
         let player = Player::new(Team::Red, Planet::Mars);


### PR DESCRIPTION
Fix overcharge only being able to be applied on units that have their special ability researched (e.g using overcharge on a Ranger requires the Ranger to have Snipe researched). This should not be necessary as overcharge also resets other types of cooldowns (according to the spec). E.g one can use overcharge to be able to move a unit multiple times in one frame.

Also fixes some compile errors when running `cargo test`.