### PR TITLE
Units should start with 10 ability heat

### DIFF
--- a/battlecode-engine/src/unit.rs
+++ b/battlecode-engine/src/unit.rs
@@ -290,8 +290,8 @@ impl Default for Unit {
             attack_cooldown: 0,
 
             is_ability_unlocked: false,
-            ability_heat: 0,
-            ability_cooldown: 10,
+            ability_heat: 10,
+            ability_cooldown: 0,
             ability_range: 0,
 
             is_built: false,
@@ -1515,5 +1515,22 @@ mod tests {
         assert_eq!(unit_b.research_level(), 2);
         assert_eq!(unit_b.worker_harvest_amount().unwrap(), 4);
         assert_eq!(unit_b.worker_build_health().unwrap(), 6);
+    }
+
+    #[test]
+    fn test_cant_use_ability_on_first_turn() {
+        let loc = MapLocation::new(Planet::Earth, 0, 0);
+
+        let mut worker = Unit::new(1, Team::Red, Worker, 0, OnMap(loc)).unwrap();
+        assert!(worker.is_ability_unlocked().is_ok(), "replicate is unlocked");
+        assert_err!(worker.ok_if_ability_ready(), GameError::Overheated);
+        worker.end_round();
+        assert!(worker.ok_if_ability_ready().is_ok());
+
+        let mut knight = Unit::new(1, Team::Red, Knight, 3, OnMap(loc)).unwrap();
+        assert!(knight.is_ability_unlocked().is_ok(), "replicate is unlocked");
+        assert_err!(knight.ok_if_ability_ready(), GameError::Overheated);
+        knight.end_round();
+        assert!(knight.ok_if_ability_ready().is_ok());
     }
 }

--- a/battlecode-engine/src/world.rs
+++ b/battlecode-engine/src/world.rs
@@ -2668,6 +2668,8 @@ mod tests {
         let robot_b = world.create_unit(Team::Red, loc_c, UnitType::Knight).unwrap();
     
         // Knight Javelin is ready
+        assert!(!world.is_javelin_ready(knight));
+        world.end_round();
         assert!(world.is_javelin_ready(knight));
 
         // Knight should not be able to javelin target outside of range
@@ -2709,6 +2711,8 @@ mod tests {
         let mage = world.create_unit(Team::Red, loc_a, UnitType::Mage).unwrap();
         
         // Mage blink is ready.
+        assert!(!world.is_blink_ready(mage));
+        world.end_round();
         assert!(world.is_blink_ready(mage));
 
         // Mage should not be able to blink to target location outside of range.
@@ -2748,7 +2752,8 @@ mod tests {
         let ranger = world.create_unit(Team::Red, loc_a, UnitType::Ranger).unwrap();
         let robot = world.create_unit(Team::Red, loc_b,UnitType::Knight).unwrap();
         // Ranger should not be able to snipe target location on a different planet.
-        assert!(world.begin_snipe(ranger, loc_c).is_err());
+        world.end_round();
+        assert_err!(world.begin_snipe(ranger, loc_c), GameError::LocationOffMap);
 
         // Ranger begins to snipe a location.
         assert!(world.begin_snipe(ranger, loc_b).is_ok());
@@ -2802,6 +2807,8 @@ mod tests {
         let robot_b = world.create_unit(Team::Red, loc_c, UnitType::Knight).unwrap();
 
         // Healer overcharge is ready.
+        assert!(!world.is_overcharge_ready(healer));
+        world.end_round();
         assert!(world.is_overcharge_ready(healer));
 
         // Healer should not be able to overcharge target robot outside of range.
@@ -3219,6 +3226,8 @@ mod tests {
 
         // The worker cannot replicate to the west, because that space is off the map.
         assert![!world.can_replicate(worker, Direction::West)];
+        assert_err![world.replicate(worker, Direction::West), GameError::Overheated];
+        world.end_round();
         assert_err![world.replicate(worker, Direction::West), GameError::LocationOffMap];
 
         // The worker cannot replicate to the east, because that space is obstructed.
@@ -3228,11 +3237,12 @@ mod tests {
         // The worker can replicate to the north.
         assert![world.can_replicate(worker, Direction::North)];
         assert![world.replicate(worker, Direction::North).is_ok()];
-        assert_eq![world.karbonite(), 85];
+        assert_eq![world.karbonite(), 93];
 
         // The child cannot replicate when there isn't enough Karbonite.
         world.my_team_mut().karbonite = 0;
         let child = world.sense_unit_at_location(MapLocation::new(Planet::Earth, 0, 1)).unwrap().unwrap().id();
+        world.end_round();
         assert![!world.can_replicate(child, Direction::North)];
         assert_err![world.replicate(child, Direction::North), GameError::InsufficientKarbonite];
 


### PR DESCRIPTION
Also wrote a test because we had set the initial ability cooldown rather than the initial ability heat, and that is a sad bug. This will fix the instant worker replication bug and match the specs.