### PR TITLE
Fix the condition for when a pre-apocalypse winner should be used

### DIFF
--- a/battlecode-engine/src/world.rs
+++ b/battlecode-engine/src/world.rs
@@ -2176,7 +2176,7 @@ impl GameWorld {
                 earth.units_by_loc.clear();
             }
             // Now we can check if the game ended.
-            if self.is_game_over().is_some() {
+            if self.are_all_units_dead() {
                 self.pre_flood_winner = Some(pre_flood_winner);
             }
         }
@@ -2246,6 +2246,13 @@ impl GameWorld {
             }
         }
         (self.end_turn(time_left_ms), error)
+    }
+
+    fn are_all_units_dead(&self) -> bool {
+        return self.get_planet(Planet::Earth).units.is_empty() &&
+            self.get_planet(Planet::Mars).units.is_empty() &&
+            self.get_team(Team::Red).units_in_space.is_empty() &&
+            self.get_team(Team::Blue).units_in_space.is_empty();
     }
 
     /// Determines if the game has ended, returning the winning team if so.


### PR DESCRIPTION
Thanks to CoatedBelt and hansonyu for spotting the bug in the code. This is an alternative to CoatedBelt's proposed fix, which was to only check `self.pre_flood_winner` in `is_game_over` when both players have zero unit value and it's the apocalypse turn.