### PR TITLE
Remove .gitignores from scaffold

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,6 +71,7 @@ package:
 	-rm -rf bc18-scaffold/examplefuncsplayer-c
 	-rm -rf bc18-scaffold/examplefuncsplayer-java
 	cp -R battlecode bc18-scaffold/battlecode
+	-find bc18-scaffold/battlecode/ -name .gitignore -delete
 	cp -R battlecode-manager bc18-scaffold/battlecode-manager
 	cp -R battlecode-maps bc18-scaffold/battlecode-maps
 	cp -R examplefuncsplayer-python bc18-scaffold/examplefuncsplayer-python


### PR DESCRIPTION
Java is broken with nodocker right now, because the scaffold is missing some files. C on Linux used to be broken for the same reason. This change should make sure similar errors are prevented in the future. (At the cost of potentially risking to include unwanted files, so caution during deploy is still warranted.)