### PR TITLE
Don't count time spent in Python towards the player

### DIFF
--- a/battlecode-manager/server.py
+++ b/battlecode-manager/server.py
@@ -564,11 +564,13 @@ def create_receive_handler(game: Game, dockers, use_docker: bool,
                     my_sandbox.unpause()
 
                     start_time = time.perf_counter()
+                    start_time_python = time.process_time()
                     self.send_message(start_turn_msg)
                     data = self.get_next_message()
+                    end_time_python = time.process_time()
                     end_time = time.perf_counter()
 
-                    diff_time = end_time-start_time
+                    diff_time = (end_time - start_time) - (end_time_python - start_time_python)
 
                     my_sandbox.pause()
 


### PR DESCRIPTION
We're seeing a lot of time spent in Python (inefficient IO?) rather than in the player in our profiles. When I add a debug print in the python time measuring code to also count Python processor self time, I get measurements like the following:

```
...
[mars:red] Turn time: 24.86
[mars:red] times 89.0 51.9
[mars:blue] times 5.0 2.8
[mars:blue] Turn time: 1.265
[earth:red] times 3.4 2.4
[earth:red] Turn time: 0.948
[earth:blue] times 2.3 1.6
[earth:blue] Turn time: 0.777
[mars:red] Turn time: 23.979
[mars:red] times 74.2 46.9
[mars:blue] times 3.6 2.5
[mars:blue] Turn time: 1.821
[earth:red] times 4.9 2.0
[earth:red] Turn time: 1.242
[earth:blue] Turn time: 0.649
[earth:blue] times 3.3 2.8
[mars:red] Turn time: 14.271
[mars:red] times 47.3 31.5
EOF
```

where "Turn time" is the value we measure from `clock()` in our C++ code, the first value of "times" is what the Python code currently measures, and the second value of "times" is the difference in `time.process_time()` for the same block of code that Python measures (lines sometimes appear in the wrong order due to buffering). It's clear that most time is spent in Python, and that the first value minus the second is a much better approximation of the time used by the bot than the current one. I get similar values outside of docker, there typically with less time spent in Python I think (but it might also just have been different maps).

This will hopefully address timeouts due to large numbers of units in upcoming tournaments. Optimizing the Python code (I'm sort of suspecting the line-buffered IO??) is left as future work. :)